### PR TITLE
Improve layout for FindPersonsPredicate class diagram

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -319,7 +319,7 @@ Evaluation:
 * For each attribute, it checks if the person's attribute contains the search value.
 
 The following class diagram shows the structure of the FindPersonPredicate:
-<puml src="diagrams/FindPersonPredicateClassDiagram.puml" width="600"/>
+<puml src="diagrams/FindPersonPredicateClassDiagram.puml" width="500"/>
 
 The following partial sequence diagram shows how the test operation works:
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -319,7 +319,7 @@ Evaluation:
 * For each attribute, it checks if the person's attribute contains the search value.
 
 The following class diagram shows the structure of the FindPersonPredicate:
-<puml src="diagrams/FindPersonPredicateClassDiagram.puml" width="800"/>
+<puml src="diagrams/FindPersonPredicateClassDiagram.puml" width="600"/>
 
 The following partial sequence diagram shows how the test operation works:
 

--- a/docs/diagrams/FindPersonPredicateClassDiagram.puml
+++ b/docs/diagrams/FindPersonPredicateClassDiagram.puml
@@ -4,7 +4,7 @@ skinparam arrowThickness 1.1
 skinparam arrowColor LOGIC_COLOR_T4
 skinparam classBackgroundColor LOGIC_COLOR
 
-class FindPersonsPredicate {}
+class FindPersonsPredicate
 class NameContainsKeywordsPredicate
 class PhoneContainsNumbersPredicate
 class EmailContainsKeywordsPredicate
@@ -13,13 +13,20 @@ class PolicyContainsNumbersPredicate
 class PolicyTypeContainsKeywordsPredicate
 class TagContainsKeywordsPredicate
 
-FindPersonsPredicate --> NameContainsKeywordsPredicate
-FindPersonsPredicate --> PhoneContainsNumbersPredicate
-FindPersonsPredicate --> EmailContainsKeywordsPredicate
-FindPersonsPredicate --> AddressContainsKeywordsPredicate
-FindPersonsPredicate --> PolicyContainsNumbersPredicate
-FindPersonsPredicate --> PolicyTypeContainsKeywordsPredicate
-FindPersonsPredicate --> TagContainsKeywordsPredicate
+FindPersonsPredicate -up-> NameContainsKeywordsPredicate
+FindPersonsPredicate -up-> PhoneContainsNumbersPredicate
+FindPersonsPredicate -up-> EmailContainsKeywordsPredicate
+FindPersonsPredicate -right-> AddressContainsKeywordsPredicate
+FindPersonsPredicate -down-> PolicyContainsNumbersPredicate
+FindPersonsPredicate -down-> PolicyTypeContainsKeywordsPredicate
+FindPersonsPredicate -down-> TagContainsKeywordsPredicate
+
+PhoneContainsNumbersPredicate -up[hidden]-> NameContainsKeywordsPredicate
+EmailContainsKeywordsPredicate -up[hidden]-> PhoneContainsNumbersPredicate
+AddressContainsKeywordsPredicate -up[hidden]-> EmailContainsKeywordsPredicate
+AddressContainsKeywordsPredicate -down[hidden]-> PolicyContainsNumbersPredicate
+PolicyContainsNumbersPredicate -down[hidden]-> PolicyTypeContainsKeywordsPredicate
+PolicyTypeContainsKeywordsPredicate -down[hidden]-> TagContainsKeywordsPredicate
 
 note "All classes implements the\nfunctional interface Predicate" as Note
 


### PR DESCRIPTION
The current diagram is too small and requires a binoculus :telescope:! This PR updates the layout of the diagram and makes everything bigger and viewable by the human eye.

Old diagram:
![image](https://github.com/user-attachments/assets/3a677d55-8540-4eb5-ad1d-10e069a6e882)

New diagram:
![image](https://github.com/user-attachments/assets/61c2535e-07a5-45c1-a7a7-6139d5559b7b)
