### PR TITLE
Bug fixes for filter command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDateCommand.java
@@ -2,12 +2,12 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.function.Predicate;
 
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.RenewalDate;
 
 /**
  * Filters clients based on policy renewal date range.
@@ -30,8 +30,8 @@ public class FilterDateCommand extends Command {
     public static final String SORT_BY_DATE = "date";
     public static final String SORT_BY_NAME = "name";
 
-    private final LocalDate startDate;
-    private final LocalDate endDate;
+    private final RenewalDate startDate;
+    private final RenewalDate endDate;
     private final String sortOrder;
 
     /**
@@ -44,12 +44,12 @@ public class FilterDateCommand extends Command {
      * @param sortOrder The sort order for filtering. If null, defaults to "date".
      * @throws NullPointerException If {@code startDate} or {@code endDate} is null.
      */
-    public FilterDateCommand(LocalDate startDate, LocalDate endDate, String sortOrder) {
+    public FilterDateCommand(RenewalDate startDate, RenewalDate endDate, String sortOrder) {
         requireNonNull(startDate);
         requireNonNull(endDate);
         this.startDate = startDate;
         this.endDate = endDate;
-        this.sortOrder = (sortOrder != null) ? sortOrder : "date";
+        this.sortOrder = sortOrder;
     }
 
     @Override
@@ -85,7 +85,7 @@ public class FilterDateCommand extends Command {
     }
 
     private Comparator<Person> sortFilterDate() {
-        if (sortOrder.equals("date")) {
+        if (sortOrder.equals(SORT_BY_DATE)) {
             return Comparator.comparing(Person::getRenewalDateValue);
         } else {
             // Sort by name (alphabetical order)

--- a/src/main/java/seedu/address/logic/commands/FilterDateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterDateCommand.java
@@ -19,12 +19,16 @@ public class FilterDateCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Filters clients whose policy renewal date "
             + "falls within the specified date range.\n"
             + "Parameters: sd/START_DATE ed/END_DATE [s/SORT_ORDER]\n"
-            + "Example: " + COMMAND_WORD + " sd/2025-03-01 ed/2025-03-31 s/name";
+            + "Example: " + COMMAND_WORD + " sd/01-03-2025 ed/31-03-2025 s/name";
 
     public static final String MESSAGE_NO_RESULTS = "No renewals found between %s and %s.";
 
     public static final String MESSAGE_FILTER_SUCCESS = "Found %d policies due for renewal"
             + " between %s and %s.";
+
+    public static final String DEFAULT_SORT = "date";
+    public static final String SORT_BY_DATE = "date";
+    public static final String SORT_BY_NAME = "name";
 
     private final LocalDate startDate;
     private final LocalDate endDate;

--- a/src/main/java/seedu/address/logic/parser/FilterDateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDateCommandParser.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FilterDateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.RenewalDate;
 
 /**
  * Parses input arguments and creates a new FilterDateCommand object.
@@ -19,13 +20,13 @@ public class FilterDateCommandParser implements Parser<FilterDateCommand> {
 
     public static final String MESSAGE_INVALID_DATE_FORMAT =
             "Invalid date format: Must be valid date in DD-MM-YYYY format";
-    private static final String MESSAGE_INVALID_START_DATE =
+    public static final String MESSAGE_INVALID_START_DATE =
             "Invalid start date: Must be valid date in DD-MM-YYYY format "
-                    + "and less than or equal to end date.";
-    private static final String MESSAGE_INVALID_END_DATE =
+                    + "and before or equal to end date.";
+    public static final String MESSAGE_INVALID_END_DATE =
             "Invalid end date: Must be valid date in DD-MM-YYYY format "
-            + "and more than or equal to start date, and within 5 years from the start date";
-    private static final String MESSAGE_INVALID_SORT =
+            + "and after or equal to start date, and within 5 years from the start date";
+    public static final String MESSAGE_INVALID_SORT =
             "Invalid sort. Use 'date' or 'name' (case-insensitive)";
     private static final int MAX_YEARS_RANGE = 5;
 
@@ -43,15 +44,15 @@ public class FilterDateCommandParser implements Parser<FilterDateCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_DATE, PREFIX_END_DATE, PREFIX_SORT_ORDER);
 
-        LocalDate startDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_START_DATE).get());
-        LocalDate endDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_END_DATE).get());
+        RenewalDate startDate = ParserUtil.parseRenewalDate(argMultimap.getValue(PREFIX_START_DATE).get());
+        RenewalDate endDate = ParserUtil.parseRenewalDate(argMultimap.getValue(PREFIX_END_DATE).get());
 
-        if (startDate.isAfter(endDate)) {
+        if (startDate.value.isAfter(endDate.value)) {
             throw new ParseException(MESSAGE_INVALID_START_DATE);
         }
 
         LocalDate maxAllowedDate = LocalDate.now().plusYears(MAX_YEARS_RANGE);
-        if (endDate.isAfter(maxAllowedDate)) {
+        if (endDate.value.isAfter(maxAllowedDate)) {
             throw new ParseException(MESSAGE_INVALID_END_DATE);
         }
 

--- a/src/main/java/seedu/address/logic/parser/FilterDateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterDateCommandParser.java
@@ -1,11 +1,13 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 
 import java.time.LocalDate;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.FilterDateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -32,10 +34,14 @@ public class FilterDateCommandParser implements Parser<FilterDateCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_START_DATE, PREFIX_END_DATE, PREFIX_SORT_ORDER);
+        String sortOrder = FilterDateCommand.DEFAULT_SORT;
 
-        if (argMultimap.getValue(PREFIX_START_DATE).isEmpty() || argMultimap.getValue(PREFIX_END_DATE).isEmpty()) {
-            throw new ParseException("Start date (sd/) and end date (ed/) are required.");
+        if (!arePrefixesPresent(argMultimap, PREFIX_START_DATE, PREFIX_END_DATE)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterDateCommand.MESSAGE_USAGE));
         }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_START_DATE, PREFIX_END_DATE, PREFIX_SORT_ORDER);
 
         LocalDate startDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_START_DATE).get());
         LocalDate endDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_END_DATE).get());
@@ -49,11 +55,26 @@ public class FilterDateCommandParser implements Parser<FilterDateCommand> {
             throw new ParseException(MESSAGE_INVALID_END_DATE);
         }
 
-        String sortOrder = argMultimap.getValue(PREFIX_SORT_ORDER).orElse("date").toLowerCase();
-        if (!sortOrder.equals("date") && !sortOrder.equals("name")) {
-            throw new ParseException(MESSAGE_INVALID_SORT);
+        if (argMultimap.getValue(PREFIX_SORT_ORDER).isPresent()) {
+            sortOrder = argMultimap.getValue(PREFIX_SORT_ORDER).get().toLowerCase();
+            if (!isValidSortOrder(sortOrder)) {
+                throw new ParseException(MESSAGE_INVALID_SORT);
+            }
         }
 
         return new FilterDateCommand(startDate, endDate, sortOrder);
+    }
+
+    private boolean isValidSortOrder(String sortOrder) {
+        return FilterDateCommand.SORT_BY_NAME.equals(sortOrder)
+                || FilterDateCommand.SORT_BY_DATE.equals(sortOrder);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -283,6 +283,7 @@ public class ParserUtil {
      * @throws ParseException if the given {@code dateStr} is invalid.
      */
     public static LocalDate parseDate(String dateStr) throws IllegalArgumentException {
+        requireNonNull(dateStr);
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
 
         try {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,9 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -274,29 +271,4 @@ public class ParserUtil {
         return policyTypeSet;
     }
 
-    /**
-     * Parses a {@code String dateStr} into a {@code LocalDate}.
-     * Leading and trailing whitespaces will be trimmed.
-     *
-     * @param dateStr The date string to parse.
-     * @return The parsed {@code LocalDate} object.
-     * @throws ParseException if the given {@code dateStr} is invalid.
-     */
-    public static LocalDate parseDate(String dateStr) throws IllegalArgumentException {
-        requireNonNull(dateStr);
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-
-        try {
-            LocalDate parsedDate = LocalDate.parse(dateStr.trim(), formatter);
-
-            //Ensure the formatted date matches the original input to prevent the invalid date to go through
-            if (!dateStr.equals(parsedDate.format(formatter))) {
-                throw new IllegalArgumentException(FilterDateCommandParser.MESSAGE_INVALID_DATE_FORMAT);
-            }
-
-            return parsedDate;
-        } catch (DateTimeParseException e) {
-            throw new IllegalArgumentException(FilterDateCommandParser.MESSAGE_INVALID_DATE_FORMAT);
-        }
-    }
 }

--- a/src/main/java/seedu/address/model/person/Policy.java
+++ b/src/main/java/seedu/address/model/person/Policy.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import java.time.LocalDate;
-
 /**
  * Represents a Person's policy in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidPolicy(String)}
@@ -105,9 +103,8 @@ public class Policy {
     /**
      * Returns true if the policy is due for renewal within the specified date range.
      */
-    public boolean isRenewalDueWithinDateRange(LocalDate startDate, LocalDate endDate) {
-        return (renewalDate.value.isEqual(startDate) || renewalDate.value.isAfter(startDate))
-                && (renewalDate.value.isEqual(endDate) || renewalDate.value.isBefore(endDate));
+    public boolean isRenewalDueWithinDateRange(RenewalDate startDate, RenewalDate endDate) {
+        return renewalDate.isRenewalDueWithinDateRange(startDate, endDate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/RenewalDate.java
+++ b/src/main/java/seedu/address/model/person/RenewalDate.java
@@ -94,6 +94,14 @@ public class RenewalDate {
         return daysUntil >= 0 && daysUntil <= days;
     }
 
+    /**
+     * Returns true if the renewal is due within the specified date range.
+     */
+    public boolean isRenewalDueWithinDateRange(RenewalDate startDate, RenewalDate endDate) {
+        return (value.isEqual(startDate.value) || value.isAfter(startDate.value))
+                && (value.isEqual(endDate.value) || value.isBefore(endDate.value));
+    }
+
     @Override
     public String toString() {
         return value.format(DATE_FORMATTER);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -87,6 +87,8 @@ public class CommandTestUtil {
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_POLICY_DESC = " " + PREFIX_POLICY + "123 456"; // spaces not allowed in policies
     public static final String INVALID_RENEWAL_DATE_DESC = " " + PREFIX_RENEWAL_DATE + "31-13-2024"; // invalid month
+    public static final String INVALID_START_DATE_DESC = " " + PREFIX_START_DATE + "30-02-2025"; // invalid day
+    public static final String INVALID_END_DATE_DESC = " " + PREFIX_END_DATE + "31-04-2025"; // invalid day
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
     public static final String INVALID_SORT_ORDER_DESC = " " + PREFIX_SORT_ORDER + "invalid"; // no such sort order
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -11,6 +12,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_POLICY_TYPE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_RENEWAL_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_ORDER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -43,6 +45,8 @@ public class CommandTestUtil {
     public static final String VALID_POLICY_BOB = "654321";
     public static final String VALID_RENEWAL_DATE_AMY = "31-12-2024";
     public static final String VALID_RENEWAL_DATE_BOB = "30-06-2024";
+    public static final String VALID_START_DATE = "01-03-2025";
+    public static final String VALID_END_DATE = "31-03-2025";
     public static final String VALID_POLICY_TYPE_LIFE = "Life";
     public static final String VALID_POLICY_TYPE_HEALTH = "Health";
     public static final String VALID_NOTE_AMY = "some note amy";
@@ -65,6 +69,8 @@ public class CommandTestUtil {
     public static final String POLICY_DESC_BOB = " " + PREFIX_POLICY + VALID_POLICY_BOB;
     public static final String RENEWAL_DATE_DESC_AMY = " " + PREFIX_RENEWAL_DATE + VALID_RENEWAL_DATE_AMY;
     public static final String RENEWAL_DATE_DESC_BOB = " " + PREFIX_RENEWAL_DATE + VALID_RENEWAL_DATE_BOB;
+    public static final String START_DATE_DESC = " " + PREFIX_START_DATE + VALID_START_DATE;
+    public static final String END_DATE_DESC = " " + PREFIX_END_DATE + VALID_END_DATE;
     public static final String POLICY_TYPE_DESC_LIFE = " " + PREFIX_POLICY_TYPE + VALID_POLICY_TYPE_LIFE;
     public static final String POLICY_TYPE_DESC_HEALTH = " " + PREFIX_POLICY_TYPE + VALID_POLICY_TYPE_HEALTH;
     public static final String NOTE_DESC_AMY = " " + PREFIX_NOTE + VALID_NOTE_AMY;

--- a/src/test/java/seedu/address/logic/commands/FilterDateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterDateCommandTest.java
@@ -3,6 +3,8 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -44,9 +46,9 @@ public class FilterDateCommandTest {
 
     @Test
     public void execute_emptyModel_noResults() {
-        LocalDate startDate = LocalDate.of(2025, 3, 1);
-        LocalDate endDate = LocalDate.of(2025, 3, 31);
-        FilterDateCommand command = new FilterDateCommand(startDate, endDate, "date");
+        RenewalDate startDate = new RenewalDate(VALID_START_DATE);
+        RenewalDate endDate = new RenewalDate(VALID_END_DATE);
+        FilterDateCommand command = new FilterDateCommand(startDate, endDate, FilterDateCommand.DEFAULT_SORT);
         CommandResult result = command.execute(model);
         assertEquals(String.format(FilterDateCommand.MESSAGE_NO_RESULTS, startDate, endDate),
                 result.getFeedbackToUser());
@@ -59,10 +61,10 @@ public class FilterDateCommandTest {
         model.addPerson(bob);
         model.addPerson(charlie);
 
-        LocalDate startDate = LocalDate.of(2025, 3, 1);
-        LocalDate endDate = LocalDate.of(2025, 3, 20);
+        RenewalDate startDate = new RenewalDate(VALID_START_DATE);
+        RenewalDate endDate = new RenewalDate("20-03-2025");
 
-        FilterDateCommand command = new FilterDateCommand(startDate, endDate, "date");
+        FilterDateCommand command = new FilterDateCommand(startDate, endDate, FilterDateCommand.DEFAULT_SORT);
         CommandResult result = command.execute(model);
 
         assertEquals(String.format(FilterDateCommand.MESSAGE_FILTER_SUCCESS, 2, startDate, endDate),
@@ -80,7 +82,8 @@ public class FilterDateCommandTest {
         model.addPerson(alice);
         model.addPerson(charlie);
 
-        FilterDateCommand command = new FilterDateCommand(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31), "name");
+        FilterDateCommand command = new FilterDateCommand(new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE), FilterDateCommand.SORT_BY_NAME);
         command.execute(model);
 
         List<Person> filteredList = model.getRenewalsList();
@@ -96,7 +99,8 @@ public class FilterDateCommandTest {
         model.addPerson(bob);
         model.addPerson(alice);
 
-        FilterDateCommand command = new FilterDateCommand(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31), "date");
+        FilterDateCommand command = new FilterDateCommand(new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE), FilterDateCommand.SORT_BY_DATE);
         command.execute(model);
 
         List<Person> filteredList = model.getRenewalsList();
@@ -115,10 +119,10 @@ public class FilterDateCommandTest {
                 .withPolicy("99999", LocalDate.of(2030, 1, 1).format(RenewalDate.DATE_FORMATTER)).build();
         model.addPerson(futurePerson);
 
-        LocalDate startDate = LocalDate.of(2025, 3, 1);
-        LocalDate endDate = LocalDate.of(2025, 3, 31);
+        RenewalDate startDate = new RenewalDate(VALID_START_DATE);
+        RenewalDate endDate = new RenewalDate(VALID_END_DATE);
 
-        FilterDateCommand command = new FilterDateCommand(startDate, endDate, null);
+        FilterDateCommand command = new FilterDateCommand(startDate, endDate, FilterDateCommand.DEFAULT_SORT);
         CommandResult result = command.execute(model);
 
         assertEquals(String.format(FilterDateCommand.MESSAGE_NO_RESULTS, startDate, endDate),
@@ -128,10 +132,14 @@ public class FilterDateCommandTest {
 
     @Test
     public void equals() {
-        FilterDateCommand command1 = new FilterDateCommand(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31), "date");
-        FilterDateCommand command2 = new FilterDateCommand(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31), "date");
-        FilterDateCommand command3 = new FilterDateCommand(LocalDate.of(2025, 4, 1), LocalDate.of(2025, 4, 30), "date");
-        FilterDateCommand command4 = new FilterDateCommand(LocalDate.of(2025, 3, 1), LocalDate.of(2025, 3, 31), "name");
+        FilterDateCommand command1 = new FilterDateCommand(new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE), FilterDateCommand.DEFAULT_SORT);
+        FilterDateCommand command2 = new FilterDateCommand(new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE), FilterDateCommand.DEFAULT_SORT);
+        FilterDateCommand command3 = new FilterDateCommand(new RenewalDate(VALID_START_DATE),
+                new RenewalDate("30-04-2025"), FilterDateCommand.DEFAULT_SORT);
+        FilterDateCommand command4 = new FilterDateCommand(new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE), FilterDateCommand.SORT_BY_NAME);
 
         assertTrue(command1.equals(command1)); //same object
         assertTrue(command1.equals(command2));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,13 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.END_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.START_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_POLICY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_RENEWAL_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.Test;
 
@@ -112,23 +113,19 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_filter() throws Exception {
-        LocalDate startDate = LocalDate.of(2025, 3, 1);
-        LocalDate endDate = LocalDate.of(2025, 3, 31);
+        RenewalDate startDate = new RenewalDate(VALID_START_DATE);
+        RenewalDate endDate = new RenewalDate(VALID_END_DATE);
 
         // Test with default parameters
         FilterDateCommand defaultCommand = (FilterDateCommand) parser.parseCommand(
-                FilterDateCommand.COMMAND_WORD + " sd/"
-                        + startDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")) + " ed/"
-                        + endDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+                FilterDateCommand.COMMAND_WORD + START_DATE_DESC + END_DATE_DESC);
         assertEquals(
                 new FilterDateCommand(startDate, endDate, "date"),
                 defaultCommand);
 
         // Test with custom parameters
         FilterDateCommand customCommand = (FilterDateCommand) parser.parseCommand(
-                FilterDateCommand.COMMAND_WORD + " sd/"
-                        + startDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")) + " ed/"
-                        + endDate.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")) + " s/name");
+                FilterDateCommand.COMMAND_WORD + START_DATE_DESC + END_DATE_DESC + " s/name");
         assertEquals(new FilterDateCommand(startDate, endDate, "name"), customCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FilterDateCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterDateCommandParserTest.java
@@ -1,38 +1,39 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.END_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SORT_ORDER_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.SORT_ORDER_DESC_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.SORT_ORDER_DESC_NAME;
 import static seedu.address.logic.commands.CommandTestUtil.START_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_END_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SORT_ORDER_DATE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SORT_ORDER_NAME;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_START_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SORT_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_DATE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.FilterDateCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.RenewalDate;
 
 public class FilterDateCommandParserTest {
 
     private final FilterDateCommandParser parser = new FilterDateCommandParser();
 
     @Test
-    public void parse_validArgs_returnsFilterDateCommand() {
+    public void parse_allArgsSpecified_success() {
         String userInput = START_DATE_DESC + END_DATE_DESC + SORT_ORDER_DESC_NAME;
         FilterDateCommand expectedCommand = new FilterDateCommand(
-                LocalDate.of(2025, 3, 1),
-                LocalDate.of(2025, 3, 31),
+                new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE),
                 VALID_SORT_ORDER_NAME
         );
 
@@ -62,109 +63,99 @@ public class FilterDateCommandParserTest {
     }
 
     @Test
-    public void parse_missingStartDate_throwsParseException() {
-        String userInput = END_DATE_DESC + SORT_ORDER_DESC_DATE;
-        assertThrows(ParseException.class, () -> parser.parse(userInput));
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterDateCommand.MESSAGE_USAGE);
+
+        // Empty input
+        assertParseFailure(parser, "", expectedMessage);
+
+        // Missing start date
+        assertParseFailure(parser, END_DATE_DESC, expectedMessage);
+
+        // Missing end date
+        assertParseFailure(parser, START_DATE_DESC, expectedMessage);
     }
 
     @Test
-    public void parse_missingEndDate_throwsParseException() {
-        String userInput = START_DATE_DESC + SORT_ORDER_DESC_NAME;
-        assertThrows(ParseException.class, () -> parser.parse(userInput));
+    public void parse_noSortOrder_defaultsToDate() {
+        String userInput = START_DATE_DESC + END_DATE_DESC;
+        FilterDateCommand expectedCommand = new FilterDateCommand(
+                new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE),
+                VALID_SORT_ORDER_DATE
+        );
+
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_startDateAfterEndDate_throwsParseException() {
-        String userInput = " sd/01-04-2025 ed/01-03-2025";
-        assertThrows(ParseException.class, () -> parser.parse(userInput));
+        assertParseFailure(parser, " sd/01-04-2025 ed/01-03-2025", FilterDateCommandParser.MESSAGE_INVALID_START_DATE);
     }
 
     @Test
     public void parse_endDateBeyondMaxYears_throwsParseException() {
-        String userInput = " sd/01-03-2025 ed/01-03-2031";
-        assertThrows(ParseException.class, () -> parser.parse(userInput));
+        assertParseFailure(parser, " sd/01-03-2025 ed/01-03-2031", FilterDateCommandParser.MESSAGE_INVALID_END_DATE);
     }
 
     @Test
     public void parse_invalidDateFormat_throwsParseException() {
-        String userInput = " sd/2025-01-01 ed/2025-03-31" + SORT_ORDER_DESC_DATE; // Incorrect date format
-        assertThrows(IllegalArgumentException.class, () -> parser.parse(userInput));
+        assertParseFailure(parser, " sd/2025-01-01 ed/2025-03-31", RenewalDate.DATE_CONSTRAINTS);
     }
 
     @Test
-    public void parse_nonExistentDate_throwsParseException() {
-        String userInput = " sd/30-02-2025 ed/31-03-2025" + SORT_ORDER_DESC_DATE; // Feb 30 does not exist
-        assertThrows(IllegalArgumentException.class, () -> parser.parse(userInput));
+    public void parse_nonExistentDate_failure() {
+        // Invalid start date
+        assertParseFailure(parser, INVALID_START_DATE_DESC + END_DATE_DESC,
+                RenewalDate.DATE_CONSTRAINTS);
+
+        // Invalid end date
+        assertParseFailure(parser, START_DATE_DESC + INVALID_END_DATE_DESC,
+                RenewalDate.DATE_CONSTRAINTS);
+
+        // Both dates invalid
+        assertParseFailure(parser, INVALID_START_DATE_DESC + INVALID_END_DATE_DESC,
+                RenewalDate.DATE_CONSTRAINTS);
     }
 
     @Test
     public void parse_nonExistentSortType_throwsParseException() {
-        String userInput = " sd/11-02-2025 ed/31-03-2025" + INVALID_SORT_ORDER_DESC;
-        assertThrows(ParseException.class, () -> parser.parse(userInput));
+        assertParseFailure(parser, START_DATE_DESC + END_DATE_DESC + INVALID_SORT_ORDER_DESC,
+                FilterDateCommandParser.MESSAGE_INVALID_SORT);
     }
 
     @Test
-    public void parse_noSortOrder_defaultsToDate() throws Exception {
-        String userInput = " sd/01-03-2025 ed/31-03-2025";
+    public void parse_caseInsensitiveSortOrder_success() {
+        String userInput = START_DATE_DESC + END_DATE_DESC + " s/NaMe"; // Mixed lower and upper case
         FilterDateCommand expectedCommand = new FilterDateCommand(
-                LocalDate.of(2025, 3, 1),
-                LocalDate.of(2025, 3, 31),
-                VALID_SORT_ORDER_DATE
-        );
-
-        assertEquals(expectedCommand, parser.parse(userInput));
-    }
-
-    @Test
-    public void parse_caseInsensitiveSortOrder_valid() throws Exception {
-        String userInput = " sd/01-03-2025 ed/31-03-2025 s/NaMe"; // Mixed lower and upper case
-        FilterDateCommand expectedCommand = new FilterDateCommand(
-                LocalDate.of(2025, 3, 1),
-                LocalDate.of(2025, 3, 31),
+                new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_END_DATE),
                 VALID_SORT_ORDER_NAME
         );
 
-        assertEquals(expectedCommand, parser.parse(userInput));
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
-    public void parse_extraSpaces_trimmedCorrectly() throws Exception {
-        String userInput = "  sd/01-03-2025   ed/31-03-2025   s/name   ";
-        FilterDateCommand expectedCommand = new FilterDateCommand(
-                LocalDate.of(2025, 3, 1),
-                LocalDate.of(2025, 3, 31),
-                VALID_SORT_ORDER_NAME
-        );
-
-        assertEquals(expectedCommand, parser.parse(userInput));
-    }
-
-    @Test
-    public void parse_emptyInput_throwsParseException() {
-        String userInput = "";
-        assertThrows(ParseException.class, () -> parser.parse(userInput));
-    }
-
-    @Test
-    public void parse_startDateEqualsEndDate_valid() throws Exception {
+    public void parse_startDateEqualsEndDate_success() {
         String userInput = " sd/01-03-2025 ed/01-03-2025" + SORT_ORDER_DESC_DATE; // Same start and end date
         FilterDateCommand expectedCommand = new FilterDateCommand(
-                LocalDate.of(2025, 3, 1),
-                LocalDate.of(2025, 3, 1),
+                new RenewalDate(VALID_START_DATE),
+                new RenewalDate(VALID_START_DATE),
                 VALID_SORT_ORDER_DATE
         );
 
-        assertEquals(expectedCommand, parser.parse(userInput));
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
-    public void parse_endDateAtMaxAllowedLimit_valid() throws Exception {
-        LocalDate startDate = LocalDate.of(2025, 3, 1);
-        LocalDate endDate = LocalDate.of(2030, 3, 1); // Max limit of 5 years
+    public void parse_endDateAtMaxAllowedLimit_success() {
+        RenewalDate startDate = new RenewalDate(VALID_START_DATE);
+        RenewalDate endDate = new RenewalDate("01-03-2030"); // Max limit of 5 years
 
         String userInput = " sd/01-03-2025 ed/01-03-2030 s/date";
         FilterDateCommand expectedCommand = new FilterDateCommand(startDate, endDate, VALID_SORT_ORDER_DATE);
 
-        assertEquals(expectedCommand, parser.parse(userInput));
+        assertParseSuccess(parser, userInput, expectedCommand);
     }
 }


### PR DESCRIPTION
* Fixes #206 
* Fixes #212
* Fixes #213 
* Fixes #219 

Summary:
* Prevent duplicate arguments
* Refactor LocalDate to use RenewalDate
 
Additionally:
* Corrects date format in command usage message
* Update invalid start and end date messages to make it clearer
* Updated missing prefix error message to be in line with the other commands
* Adds test cases for duplicate prefix checking
* Updates all existing test cases for filter command and its parser

Test cases have yet to be written for the following methods:
* `seedu/address/model/person/Policy.java` isRenewalDueWithinDateRange(RenewalDate, RenewalDate)
* `seedu/address/model/person/RenewalDate.java` isRenewalDueWithinDateRange(RenewalDate, RenewalDate)